### PR TITLE
Specify explicit versions for every dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
         "name": "Dominik Jungowski"
     },
     "dependencies": {
-        "express":      "*",
-        "ejs":          "*",
-        "iniparser":    "*",
-        "websocket":    "*",
-        "i18n":         "*",
-        "jasmine-node": "*"
+        "express":      "^3.9.0",
+        "ejs":          "^1.0.0",
+        "iniparser":    "^1.0.5",
+        "websocket":    "^1.0.8",
+        "i18n":         "^0.4.1",
+        "jasmine-node": "^1.14.3"
     }
 }


### PR DESCRIPTION
Always accept the latest version of a package isn't a good idea. For example, right now express 4.x is out, but your project can only handle express 3.x.
